### PR TITLE
Shorten summary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(name='webcolors',
       version='1.6',
-      description='A library for working with color names and color value formats defined by the HTML and CSS specifications for use in documents on the Web.',
+      description='Library for working with HTML/CSS color formats in Python.',
       long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
       author='James Bennett',
       author_email='james@b-list.org',


### PR DESCRIPTION
The summary felt a bit long here. Though the GitHub summary was shorter and clearer. So, this changes to using the same summary string as is on GitHub.
