### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,4 +34,4 @@ serialization algorithms. For example, parsing the infamous
     >>> webcolors.html5_parse_legacy_color(u'chucknorris')
     (192, 0, 0)
 
-Full documentation is `available online <http://webcolors.readthedocs.org/>`_.
+Full documentation is `available online <https://webcolors.readthedocs.io/>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
