### PR TITLE
Feature/closest colour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *.pyc
 __pycache__
 *.egg-info
@@ -8,3 +9,4 @@ dist/
 .tox/
 .mypy_cache
 build/
+venv/

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -28,6 +28,20 @@ class HexConversionTests(unittest.TestCase):
         for hex_value, name in test_pairs:
             assert name == webcolors.hex_to_name(hex_value)
 
+    def test_hex_to_name_closest(self):
+        """
+        Test conversion from hex to closest color name.
+        """
+        test_pairs = (
+            ("#fffffe", "white"),
+            ("#ffe", "ivory"),
+            ("#000081", "navy"),
+            ("#daa521", "goldenrod"),
+        )
+
+        for hex_value, name in test_pairs:
+            assert name == webcolors.hex_to_name_closest(hex_value)
+
     def test_hex_to_name_unnamed(self):
         """
         A hex code which does not correspond to a named color, or does
@@ -112,6 +126,21 @@ class IntegerRGBConversionTests(unittest.TestCase):
 
         for triplet, name in test_pairs:
             assert name == webcolors.rgb_to_name(triplet)
+
+    def test_rgb_to_name_closest(self):
+        """
+        Test conversion from integer RGB triplet to closest color name.
+
+        """
+        test_pairs = (
+            ((255, 255, 250), "white"),
+            ((0, 0, 120), "navy"),
+            ((218, 165, 30), "goldenrod"),
+            (webcolors.IntegerRGB(218, 165, 30), "goldenrod"),
+        )
+
+        for triplet, name in test_pairs:
+            assert name == webcolors.rgb_to_name_closest(triplet)
 
     def test_rgb_to_name_unnamed(self):
         """
@@ -282,6 +311,20 @@ class PercentRGBConversionTests(unittest.TestCase):
 
         for triplet, name in test_pairs:
             assert name == webcolors.rgb_percent_to_name(triplet)
+
+    def test_rgb_percent_to_name_closest(self):
+        """
+        Test conversion from percent RGB triplet to closest color name.
+        """
+        test_pairs = (
+            (("100%", "100%", "98%"), "white"),
+            (("0%", "0%", "48%"), "navy"),
+            (("85.49%", "64.71%", "10.5%"), "goldenrod"),
+            (webcolors.PercentRGB("85.49%", "64.71%", "10.5%"), "goldenrod"),
+        )
+
+        for triplet, name in test_pairs:
+            assert name == webcolors.rgb_percent_to_name_closest(triplet)
 
     def test_rgb_percent_to_name_unnamed(self):
         """


### PR DESCRIPTION
Introduction of functions to obtain the closest normalised colour name if no exact name exists when perfoming hex to name, rgb to name and rgb percent to name conversions.

To perform the calculations necessary to obtain the closest colour name, the user provides a function of their choice to be used. The default function provided is squared error (mean has no effect in this case) which if given two vectors, v1 and v2, uses the formula (v1[0]-v2[0])**2 + (v1[1]-v2[1])**2 + (v1[2]-v2[2])**2.
